### PR TITLE
fix: update require path for csv-parse to match defined exports.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "prettytable",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "csv-parse": "latest"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.0.4.tgz",
+      "integrity": "sha512-5AIdl8l6n3iYQYxan5djB5eKDa+vBnhfWZtRpJTcrETWfVLYN0WSj3L9RwvgYt+psoO77juUr8TG8qpfGZifVQ=="
+    }
+  },
+  "dependencies": {
+    "csv-parse": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.0.4.tgz",
+      "integrity": "sha512-5AIdl8l6n3iYQYxan5djB5eKDa+vBnhfWZtRpJTcrETWfVLYN0WSj3L9RwvgYt+psoO77juUr8TG8qpfGZifVQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettytable",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "main": "prettytable.js",
   "description": "CLI based Node module for generating pretty tables from multiple data sources",
   "keywords": ["table", "cli table", "csv", "json"],

--- a/prettytable.js
+++ b/prettytable.js
@@ -1,4 +1,4 @@
-var parse = require('csv-parse/lib/sync');
+var parse = require('csv-parse/sync');
 var fs = require('fs');
 
 var PrettyTable = function () {


### PR DESCRIPTION
## Summary

Updates the require path to `csv-parse` to match the defined [`exports`](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/package.json#L37-L39) for the dependency.

This fixes the following error message when using `prettytable`:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/sync' is not defined by "exports" in node_modules\csv-parse\package.json
```

Might want to consider locking down the `csv-parse` dependency to a specific version in `package.json` too.
